### PR TITLE
feat: add debate comparison modes

### DIFF
--- a/client/src/components/ComparisonForm.tsx
+++ b/client/src/components/ComparisonForm.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { AnalysisResult, OpenRouterModel } from "@shared/schema";
+import { analyzeArgument } from "@/lib/api";
+import { getAppConfig, AppConfig } from "@/lib/config";
+import { computeSimilarity, buildScorecard, ArgumentScorecard } from "@/lib/insights";
+
+export interface DualArgumentResult {
+  left: {
+    text: string;
+    result: AnalysisResult;
+    scorecard: ArgumentScorecard;
+  };
+  right: {
+    text: string;
+    result: AnalysisResult;
+    scorecard: ArgumentScorecard;
+  };
+  similarity: number;
+}
+
+interface ComparisonFormProps {
+  onComparisonReady: (
+    isLoading: boolean,
+    error: string | null,
+    result: DualArgumentResult | null,
+    model: string
+  ) => void;
+}
+
+const EXAMPLE_MATCHUPS = [
+  {
+    title: "Climate Policy",
+    left:
+      "Climate change is a hoax because winters are still cold and natural cycles explain temperature shifts better than human activity.",
+    right:
+      "Overwhelming scientific consensus shows human activity drives current warming trends, with record temperatures and extreme weather events providing evidence.",
+  },
+  {
+    title: "Technology in Education",
+    left:
+      "Tablets in classrooms distract students and replace critical thinking with shallow internet searches.",
+    right:
+      "When guided well, educational technology offers personalized practice and expands access to high-quality materials for underserved students.",
+  },
+  {
+    title: "Economic Stimulus",
+    left:
+      "Government spending packages balloon debt and inevitably trigger inflation that hurts working families the most.",
+    right:
+      "Strategic stimulus during downturns prevents layoffs, sustains consumer demand, and historically shortens recessions without long-term inflation spikes.",
+  },
+];
+
+export function ComparisonForm({ onComparisonReady }: ComparisonFormProps) {
+  const [leftText, setLeftText] = useState("");
+  const [rightText, setRightText] = useState("");
+  const [model, setModel] = useState("openrouter");
+  const [openRouterModel, setOpenRouterModel] = useState<OpenRouterModel>(
+    "mistralai/mistral-7b-instruct:free"
+  );
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAppConfig()
+      .then((appConfig) => {
+        setConfig(appConfig);
+        setModel(appConfig.defaultAIModel);
+        setOpenRouterModel(appConfig.defaultOpenRouterModel as OpenRouterModel);
+      })
+      .catch(console.error);
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    if (!leftText.trim() || !rightText.trim()) {
+      const message = "Enter arguments for both sides to compare them.";
+      setLocalError(message);
+      onComparisonReady(false, message, null, model);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      onComparisonReady(true, null, null, model);
+
+      const [leftResult, rightResult] = await Promise.all([
+        model === "openrouter"
+          ? analyzeArgument(leftText, model, openRouterModel)
+          : analyzeArgument(leftText, model),
+        model === "openrouter"
+          ? analyzeArgument(rightText, model, openRouterModel)
+          : analyzeArgument(rightText, model),
+      ]);
+
+      const comparison: DualArgumentResult = {
+        left: {
+          text: leftText,
+          result: leftResult,
+          scorecard: buildScorecard(leftResult),
+        },
+        right: {
+          text: rightText,
+          result: rightResult,
+          scorecard: buildScorecard(rightResult),
+        },
+        similarity: computeSimilarity(leftText, rightText),
+      };
+
+      onComparisonReady(false, null, comparison, model);
+    } catch (error) {
+      console.error("Comparison analysis failed", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to analyze arguments. Please try again.";
+      setLocalError(message);
+      onComparisonReady(false, message, null, model);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="neo-card p-6">
+      <div className="bg-secondary text-secondary-foreground p-4 mb-6 neo-border neo-shadow-secondary">
+        <h2 className="text-2xl font-bold uppercase tracking-wider font-arvo">
+          ⚖️ Dual Argument Analyzer
+        </h2>
+        <p className="text-sm opacity-90 mt-2">
+          Compare the structure, strength, and tone of two opposing arguments side-by-side.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <Label className="font-arvo">Quick start with an example matchup</Label>
+          <Select
+            onValueChange={(value) => {
+              const preset = EXAMPLE_MATCHUPS.find((item) => item.title === value);
+              if (preset) {
+                setLeftText(preset.left);
+                setRightText(preset.right);
+              }
+            }}
+            disabled={isLoading}
+          >
+            <SelectTrigger className="neo-select mt-2">
+              <SelectValue placeholder="Select a debate to auto-fill both sides" />
+            </SelectTrigger>
+            <SelectContent>
+              {EXAMPLE_MATCHUPS.map((item) => (
+                <SelectItem key={item.title} value={item.title}>
+                  {item.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="leftArgument" className="font-arvo">
+              Argument A
+            </Label>
+            <Textarea
+              id="leftArgument"
+              value={leftText}
+              onChange={(event) => setLeftText(event.target.value)}
+              placeholder="Paste the first argument here"
+              className="resize-none min-h-[160px] neo-input font-semibold"
+              disabled={isLoading}
+            />
+          </div>
+          <div>
+            <Label htmlFor="rightArgument" className="font-arvo">
+              Argument B
+            </Label>
+            <Textarea
+              id="rightArgument"
+              value={rightText}
+              onChange={(event) => setRightText(event.target.value)}
+              placeholder="Paste the opposing argument here"
+              className="resize-none min-h-[160px] neo-input font-semibold"
+              disabled={isLoading}
+            />
+          </div>
+        </div>
+
+        <div>
+          <Label className="font-arvo">Select AI Provider</Label>
+          <Select value={model} onValueChange={setModel} disabled={isLoading}>
+            <SelectTrigger className="mt-2">
+              <SelectValue placeholder="Select an AI provider" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="openrouter">OpenRouter (Free)</SelectItem>
+              <SelectItem value="openai">OpenAI (Clone repo to use)</SelectItem>
+              <SelectItem value="deepseek">DeepSeek (Clone repo to use)</SelectItem>
+              <SelectItem value="gemini">Google (Clone repo to use)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {model === "openrouter" && config && (
+          <div>
+            <Label className="font-arvo">OpenRouter Model</Label>
+            <Select
+              value={openRouterModel}
+              onValueChange={(value) => setOpenRouterModel(value as OpenRouterModel)}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="mt-2">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {config.openRouterModels.map((modelOption) => (
+                  <SelectItem key={modelOption} value={modelOption}>
+                    {modelOption}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {localError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{localError}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? (
+            <span className="flex items-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" /> Analyzing arguments...
+            </span>
+          ) : (
+            "Run comparison"
+          )}
+        </Button>
+      </form>
+    </div>
+  );
+}
+

--- a/client/src/components/ComparisonResults.tsx
+++ b/client/src/components/ComparisonResults.tsx
@@ -1,0 +1,228 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { Sparkles, Scale, Flame, GitBranch } from "lucide-react";
+import { DualArgumentResult } from "./ComparisonForm";
+
+interface ComparisonResultsProps {
+  result: DualArgumentResult | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const metricLabel = (score: number) => `${score}%`;
+
+export function ComparisonResults({ result, isLoading, error }: ComparisonResultsProps) {
+  const fallacyRows = useMemo(() => {
+    if (!result) return [] as string[];
+    const names = new Set<string>();
+    result.left.result.fallacies?.forEach((f) => names.add(f.name));
+    result.right.result.fallacies?.forEach((f) => names.add(f.name));
+    return Array.from(names);
+  }, [result]);
+
+  if (isLoading) {
+    return (
+      <Card className="neo-card">
+        <CardContent className="py-16 text-center font-arvo text-lg">
+          Crunching both arguments…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="neo-card border-destructive/40">
+        <CardContent className="py-8 text-destructive font-medium">{error}</CardContent>
+      </Card>
+    );
+  }
+
+  if (!result) {
+    return null;
+  }
+
+  const similarityPercent = Math.round(result.similarity * 100);
+
+  const narrativePoints = (label: string, text: string, premises: string[], counters?: string[]) => (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <GitBranch className="h-5 w-5 text-primary" />
+        <h3 className="font-semibold text-lg">{label}</h3>
+      </div>
+      <div className="neo-subtle rounded-lg p-4 space-y-3">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">Central Claim</p>
+          <p className="font-semibold leading-relaxed">{text}</p>
+        </div>
+        <div>
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">Supporting Premises</p>
+          <ul className="list-disc list-inside space-y-1">
+            {premises.map((premise, index) => (
+              <li key={index} className="text-sm leading-snug">
+                {premise}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {counters && counters.length > 0 && (
+          <div>
+            <p className="text-sm uppercase tracking-wide text-muted-foreground">Counter-moves</p>
+            <ul className="list-disc list-inside space-y-1">
+              {counters.map((item, index) => (
+                <li key={index} className="text-sm leading-snug">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card className="neo-card">
+        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="font-arvo text-2xl uppercase tracking-wide">
+              Comparative Insight Dashboard
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Highlighting structural strengths, fallacy risks, and alignment between the two arguments.
+            </p>
+          </div>
+          <Badge className="text-base px-3 py-1 bg-primary/10 text-primary border-primary/40">
+            Similarity {similarityPercent}%
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <p className="text-sm font-semibold mb-2 flex items-center gap-2">
+              <Scale className="h-4 w-4" /> Semantic alignment score
+            </p>
+            <Progress value={similarityPercent} className="h-2" />
+            <p className="text-xs text-muted-foreground mt-1">
+              A higher score indicates overlapping language and concepts, while a lower score suggests divergent framing.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-4">
+            {[result.left, result.right].map((side, index) => (
+              <Card key={index} className="neo-subtle">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Sparkles className="h-4 w-4 text-primary" />
+                    {index === 0 ? "Argument A Scorecard" : "Argument B Scorecard"}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <div className="flex justify-between">
+                    <span>Coherence</span>
+                    <span className="font-semibold">{metricLabel(side.scorecard.coherence)}</span>
+                  </div>
+                  <Progress value={side.scorecard.coherence} className="h-1.5" />
+                  <div className="flex justify-between">
+                    <span>Support</span>
+                    <span className="font-semibold">{metricLabel(side.scorecard.support)}</span>
+                  </div>
+                  <Progress value={side.scorecard.support} className="h-1.5" />
+                  <div className="flex justify-between">
+                    <span>Tone Stability</span>
+                    <span className="font-semibold">{metricLabel(side.scorecard.tone)}</span>
+                  </div>
+                  <Progress value={side.scorecard.tone} className="h-1.5" />
+                  <div className="flex justify-between">
+                    <span>Fallacy Safety</span>
+                    <span className="font-semibold">{metricLabel(side.scorecard.fallacyRisk)}</span>
+                  </div>
+                  <Progress value={side.scorecard.fallacyRisk} className="h-1.5" />
+                  <Separator className="my-2" />
+                  <p className="text-muted-foreground leading-relaxed">
+                    {side.scorecard.summary}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {fallacyRows.length > 0 ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Flame className="h-4 w-4 text-destructive" />
+                <h3 className="font-semibold text-lg">Fallacy heatmap</h3>
+              </div>
+              <div className="overflow-hidden rounded-xl border bg-background">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/60 text-left">
+                    <tr>
+                      <th className="p-3 font-semibold">Fallacy</th>
+                      <th className="p-3 font-semibold">Argument A</th>
+                      <th className="p-3 font-semibold">Argument B</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {fallacyRows.map((name) => {
+                      const leftCount = result.left.result.fallacies?.filter((f) => f.name === name).length ?? 0;
+                      const rightCount = result.right.result.fallacies?.filter((f) => f.name === name).length ?? 0;
+                      const intensity = Math.min(leftCount + rightCount, 4) / 4;
+                      const background = `rgba(239, 68, 68, ${0.1 + intensity * 0.4})`;
+                      return (
+                        <tr key={name} className="border-t">
+                          <td className="p-3 font-medium">{name}</td>
+                          <td className="p-3">
+                            <span
+                              className="px-2 py-1 rounded-md font-semibold"
+                              style={{ backgroundColor: leftCount ? background : "transparent" }}
+                            >
+                              {leftCount || "—"}
+                            </span>
+                          </td>
+                          <td className="p-3">
+                            <span
+                              className="px-2 py-1 rounded-md font-semibold"
+                              style={{ backgroundColor: rightCount ? background : "transparent" }}
+                            >
+                              {rightCount || "—"}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Darker tones indicate higher frequency or severity of the highlighted fallacy.
+              </p>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No fallacies detected in either argument—excellent logical hygiene.
+            </div>
+          )}
+
+          <div className="grid md:grid-cols-2 gap-4">
+            {narrativePoints(
+              "Argument A narrative flow",
+              result.left.result.claim,
+              result.left.result.premises,
+              result.left.result.counterArguments
+            )}
+            {narrativePoints(
+              "Argument B narrative flow",
+              result.right.result.claim,
+              result.right.result.premises,
+              result.right.result.counterArguments
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/client/src/components/DebateArena.tsx
+++ b/client/src/components/DebateArena.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2, Swords, Crown, TrendingUp } from "lucide-react";
+import { analyzeArgument } from "@/lib/api";
+import { AnalysisResult, OpenRouterModel } from "@shared/schema";
+import { getAppConfig, AppConfig } from "@/lib/config";
+import { DebateRoundInsight, buildScorecard, calculateMomentum, DebateMomentum } from "@/lib/insights";
+import { Progress } from "@/components/ui/progress";
+
+interface DebateArenaProps {
+  onDebateUpdate?: (rounds: DebateRoundInsight[], momentum: DebateMomentum, model: string) => void;
+}
+
+interface DebateRound extends DebateRoundInsight {
+  turn: number;
+}
+
+export function DebateArena({ onDebateUpdate }: DebateArenaProps) {
+  const [affirmativeName, setAffirmativeName] = useState("Affirmative");
+  const [negativeName, setNegativeName] = useState("Negative");
+  const [model, setModel] = useState("openrouter");
+  const [openRouterModel, setOpenRouterModel] = useState<OpenRouterModel>(
+    "mistralai/mistral-7b-instruct:free"
+  );
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [currentText, setCurrentText] = useState("");
+  const [currentSpeaker, setCurrentSpeaker] = useState<"affirmative" | "negative">("affirmative");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rounds, setRounds] = useState<DebateRound[]>([]);
+
+  useEffect(() => {
+    getAppConfig()
+      .then((appConfig) => {
+        setConfig(appConfig);
+        setModel(appConfig.defaultAIModel);
+        setOpenRouterModel(appConfig.defaultOpenRouterModel as OpenRouterModel);
+      })
+      .catch(console.error);
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!currentText.trim()) {
+      setError("Enter a statement to keep the debate moving.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+
+      const result: AnalysisResult =
+        model === "openrouter"
+          ? await analyzeArgument(currentText, model, openRouterModel)
+          : await analyzeArgument(currentText, model);
+
+      const insight: DebateRound = {
+        turn: rounds.length + 1,
+        speaker: currentSpeaker,
+        text: currentText,
+        result,
+        scorecard: buildScorecard(result),
+      };
+
+      const updatedRounds = [...rounds, insight];
+      setRounds(updatedRounds);
+      setCurrentText("");
+      setCurrentSpeaker(currentSpeaker === "affirmative" ? "negative" : "affirmative");
+
+      const momentum = calculateMomentum(updatedRounds);
+      onDebateUpdate?.(updatedRounds, momentum, model);
+    } catch (analysisError) {
+      console.error("Debate analysis failed", analysisError);
+      const message =
+        analysisError instanceof Error
+          ? analysisError.message
+          : "Unable to analyze this turn.";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const activeName = currentSpeaker === "affirmative" ? affirmativeName : negativeName;
+
+  const momentum = useMemo(() => calculateMomentum(rounds), [rounds]);
+
+  const totalMomentum = momentum.affirmative + momentum.negative || 1;
+  const affirmativeMomentum = Math.round((momentum.affirmative / totalMomentum) * 100);
+  const negativeMomentum = 100 - affirmativeMomentum;
+
+  return (
+    <div className="space-y-6">
+      <Card className="neo-card">
+        <CardHeader>
+          <CardTitle className="font-arvo text-2xl uppercase tracking-wide flex items-center gap-2">
+            <Swords className="h-5 w-5" /> Live Debate Arena
+          </CardTitle>
+          <p className="text-sm text-muted-foreground mt-2">
+            Alternate turns, analyze each response, and watch momentum shift as the debate unfolds.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <Label className="font-arvo">Affirmative side label</Label>
+              <Textarea
+                value={affirmativeName}
+                onChange={(event) => setAffirmativeName(event.target.value)}
+                className="neo-input resize-none"
+                rows={1}
+              />
+            </div>
+            <div>
+              <Label className="font-arvo">Negative side label</Label>
+              <Textarea
+                value={negativeName}
+                onChange={(event) => setNegativeName(event.target.value)}
+                className="neo-input resize-none"
+                rows={1}
+              />
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <Label className="font-arvo">Select AI Provider</Label>
+              <Select value={model} onValueChange={setModel} disabled={isLoading}>
+                <SelectTrigger className="mt-2">
+                  <SelectValue placeholder="Select an AI provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="openrouter">OpenRouter (Free)</SelectItem>
+                  <SelectItem value="openai">OpenAI (Clone repo to use)</SelectItem>
+                  <SelectItem value="deepseek">DeepSeek (Clone repo to use)</SelectItem>
+                  <SelectItem value="gemini">Google (Clone repo to use)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {model === "openrouter" && config && (
+              <div>
+                <Label className="font-arvo">OpenRouter Model</Label>
+                <Select
+                  value={openRouterModel}
+                  onValueChange={(value) => setOpenRouterModel(value as OpenRouterModel)}
+                  disabled={isLoading}
+                >
+                  <SelectTrigger className="mt-2">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {config.openRouterModels.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <Label className="font-arvo">
+              {activeName} — craft your next move
+            </Label>
+            <Textarea
+              value={currentText}
+              onChange={(event) => setCurrentText(event.target.value)}
+              placeholder="Compose your rebuttal or next point"
+              className="neo-input resize-none min-h-[160px]"
+              disabled={isLoading}
+            />
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Button type="submit" disabled={isLoading} className="w-full">
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Analyzing turn…
+                </span>
+              ) : (
+                "Submit turn"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {rounds.length > 0 && (
+        <Card className="neo-card">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-xl">
+              <TrendingUp className="h-5 w-5 text-primary" /> Momentum Tracker
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Scores combine coherence, evidence, tone, and logical safety to illustrate debate strength over time.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm font-semibold">
+                <span>{affirmativeName}</span>
+                <span>{negativeName}</span>
+              </div>
+              <Progress value={affirmativeMomentum} className="h-2" />
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>{affirmativeMomentum}% momentum</span>
+                <span>{negativeMomentum}% momentum</span>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {rounds.map((round) => (
+                <div key={round.turn} className="border rounded-lg p-4 neo-subtle space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-semibold">
+                      Round {round.turn}: {round.speaker === "affirmative" ? affirmativeName : negativeName}
+                    </span>
+                    <span className="flex items-center gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+                      <Crown className="h-3 w-3" /> Score {Math.round(
+                        (round.scorecard.coherence +
+                          round.scorecard.support +
+                          round.scorecard.tone +
+                          round.scorecard.fallacyRisk) /
+                          4
+                      )}
+                    </span>
+                  </div>
+                  <p className="text-sm leading-relaxed">{round.text}</p>
+                  <div className="grid grid-cols-2 gap-2 text-xs">
+                    <InsightMeter label="Coherence" value={round.scorecard.coherence} />
+                    <InsightMeter label="Support" value={round.scorecard.support} />
+                    <InsightMeter label="Tone" value={round.scorecard.tone} />
+                    <InsightMeter label="Fallacy Safety" value={round.scorecard.fallacyRisk} />
+                  </div>
+                  <p className="text-xs text-muted-foreground">{round.scorecard.summary}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function InsightMeter({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between">
+        <span>{label}</span>
+        <span className="font-semibold">{Math.round(value)}%</span>
+      </div>
+      <Progress value={value} className="h-1.5" />
+    </div>
+  );
+}
+

--- a/client/src/components/ResultsDisplay.tsx
+++ b/client/src/components/ResultsDisplay.tsx
@@ -49,11 +49,11 @@ export default function ResultsDisplay({
               {
                 label: "Emotion Intensity (1-5)",
                 data: [
-                  result.emotions.Anger,
-                  result.emotions.Sadness,
-                  result.emotions.Joy,
-                  result.emotions.Fear,
-                  result.emotions.Surprise,
+                  result.emotions.Anger ?? 0,
+                  result.emotions.Sadness ?? 0,
+                  result.emotions.Joy ?? 0,
+                  result.emotions.Fear ?? 0,
+                  result.emotions.Surprise ?? 0,
                 ],
                 backgroundColor: [
                   "rgba(239, 68, 68, 0.8)",    // Red for Anger

--- a/client/src/lib/insights.ts
+++ b/client/src/lib/insights.ts
@@ -1,0 +1,125 @@
+import { AnalysisResult } from "@shared/schema";
+
+export interface ArgumentScorecard {
+  coherence: number;
+  support: number;
+  tone: number;
+  fallacyRisk: number;
+  summary: string;
+}
+
+const clampScore = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+
+export function buildScorecard(result: AnalysisResult): ArgumentScorecard {
+  const hasClaim = result.claim.trim().length > 0;
+  const premiseCount = result.premises?.filter((p) => p.trim().length > 0).length ?? 0;
+  const fallacyCount = result.fallacies?.length ?? 0;
+  const counterCount = result.counterArguments?.length ?? 0;
+
+  const coherenceBase = hasClaim ? 60 : 40;
+  const coherence = clampScore(
+    coherenceBase + Math.min(premiseCount * 6, 30) + Math.min(counterCount * 4, 10)
+  );
+
+  const support = clampScore(35 + Math.min(premiseCount * 12, 55));
+
+  const emotionValues = Object.values(result.emotions || {});
+  const avgEmotion = emotionValues.length
+    ? emotionValues.reduce((acc, value) => acc + (value ?? 0), 0) / emotionValues.length
+    : 0;
+  const tone = clampScore(80 - Math.abs(avgEmotion - 2.5) * 15);
+
+  const fallacyRisk = clampScore(100 - Math.min(fallacyCount * 18, 70));
+
+  const insights: string[] = [];
+  if (premiseCount >= 3) {
+    insights.push("Well supported with multiple premises.");
+  } else if (premiseCount === 0) {
+    insights.push("Needs evidence to back up the main claim.");
+  } else {
+    insights.push("Could benefit from additional supporting evidence.");
+  }
+
+  if (fallacyCount === 0) {
+    insights.push("No fallacies detected—strong logical footing.");
+  } else if (fallacyCount <= 2) {
+    insights.push("Minor fallacy risk worth addressing.");
+  } else {
+    insights.push("High fallacy risk—review reasoning carefully.");
+  }
+
+  if (counterCount > 0) {
+    insights.push("Considers opposing viewpoints.");
+  }
+
+  const summary = insights.join(" ");
+
+  return {
+    coherence,
+    support,
+    tone,
+    fallacyRisk,
+    summary,
+  };
+}
+
+const tokenize = (input: string) =>
+  input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 2);
+
+export function computeSimilarity(textA: string, textB: string): number {
+  const tokensA = new Set(tokenize(textA));
+  const tokensB = new Set(tokenize(textB));
+
+  if (tokensA.size === 0 || tokensB.size === 0) {
+    return 0;
+  }
+
+  let intersection = 0;
+  tokensA.forEach((token) => {
+    if (tokensB.has(token)) {
+      intersection += 1;
+    }
+  });
+
+  const combined = new Set<string>();
+  tokensA.forEach((token) => combined.add(token));
+  tokensB.forEach((token) => combined.add(token));
+  const union = combined.size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export interface DebateMomentum {
+  affirmative: number;
+  negative: number;
+}
+
+export interface DebateRoundInsight {
+  speaker: "affirmative" | "negative";
+  text: string;
+  result: AnalysisResult;
+  scorecard: ArgumentScorecard;
+}
+
+export function calculateMomentum(rounds: DebateRoundInsight[]): DebateMomentum {
+  return rounds.reduce(
+    (acc, round) => {
+      const contribution =
+        round.scorecard.coherence * 0.25 +
+        round.scorecard.support * 0.35 +
+        round.scorecard.fallacyRisk * 0.2 +
+        round.scorecard.tone * 0.2;
+      if (round.speaker === "affirmative") {
+        acc.affirmative += contribution;
+      } else {
+        acc.negative += contribution;
+      }
+      return acc;
+    },
+    { affirmative: 0, negative: 0 }
+  );
+}
+

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,20 +1,35 @@
 import React from "react";
-import { motion } from "framer-motion";
 import Hero from "@/components/Hero";
 import ApiGuide from "@/components/ApiGuide";
 import ArgumentForm from "@/components/ArgumentForm";
 import ResultsDisplay from "@/components/ResultsDisplay";
-import { Footer } from "@/components/Footer"; // Fixed import - using named export
+import { ComparisonForm, DualArgumentResult } from "@/components/ComparisonForm";
+import { ComparisonResults } from "@/components/ComparisonResults";
+import { DebateArena } from "@/components/DebateArena";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Activity, Trophy } from "lucide-react";
+import { DebateMomentum, DebateRoundInsight } from "@/lib/insights";
 
 export default function Home() {
   const [result, setResult] = React.useState<any>(null);
-  const [argumentText, setArgumentText] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [selectedModel, setSelectedModel] = React.useState("openai");
   const resultsRef = React.useRef<HTMLDivElement>(null);
+  const comparisonRef = React.useRef<HTMLDivElement>(null);
+  const debateRef = React.useRef<HTMLDivElement>(null);
 
-  // Function to handle when analysis is requested
+  const [mode, setMode] = React.useState("single");
+
+  const [comparisonResult, setComparisonResult] = React.useState<DualArgumentResult | null>(null);
+  const [comparisonLoading, setComparisonLoading] = React.useState(false);
+  const [comparisonError, setComparisonError] = React.useState<string | null>(null);
+
+  const [debateRounds, setDebateRounds] = React.useState<DebateRoundInsight[]>([]);
+  const [debateMomentum, setDebateMomentum] = React.useState<DebateMomentum | null>(null);
+  const [debateModel, setDebateModel] = React.useState("openrouter");
+
   const handleAnalysisRequested = (
     isLoading: boolean,
     error: string | null,
@@ -25,36 +40,125 @@ export default function Home() {
     setError(error);
     setResult(result);
     setSelectedModel(model);
-    
-    // Scroll to results when they're available
+
     if (result && resultsRef.current) {
       resultsRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  const handleComparisonRequested = (
+    isLoading: boolean,
+    error: string | null,
+    result: DualArgumentResult | null,
+    model: string
+  ) => {
+    setComparisonLoading(isLoading);
+    setComparisonError(error);
+    if (!isLoading) {
+      setComparisonResult(result);
+      if (result && comparisonRef.current) {
+        comparisonRef.current.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  };
+
+  const handleDebateUpdate = (
+    rounds: DebateRoundInsight[],
+    momentum: DebateMomentum,
+    model: string
+  ) => {
+    setDebateRounds(rounds);
+    setDebateMomentum(momentum);
+    setDebateModel(model);
+
+    if (rounds.length > 0 && debateRef.current) {
+      debateRef.current.scrollIntoView({ behavior: "smooth" });
     }
   };
 
   return (
     <div className="min-h-screen bg-background">
       <Hero />
-      
+
       <div className="container mx-auto px-4 py-6">
-        <div className="flex flex-col gap-6 max-w-4xl mx-auto">
-          {/* Analysis Form */}
-          <ArgumentForm
-            onAnalysisRequested={handleAnalysisRequested}
-            isLoading={isLoading}
-          />
-          
-          {/* Results Display (only shown when results are available) */}
-          <div ref={resultsRef} className="mt-2">
-            <ResultsDisplay
-              result={result}
-              isLoading={isLoading}
-              error={error}
-              selectedModel={selectedModel}
-            />
-          </div>
-          
-          {/* Information Section */}
+        <div className="flex flex-col gap-6 max-w-5xl mx-auto">
+          <Tabs value={mode} onValueChange={setMode} className="space-y-4">
+            <TabsList className="grid grid-cols-1 md:grid-cols-3 gap-2 neo-subtle p-2">
+              <TabsTrigger value="single" className="text-sm font-semibold">
+                Single critique
+              </TabsTrigger>
+              <TabsTrigger value="comparison" className="text-sm font-semibold">
+                Dual analyzer
+              </TabsTrigger>
+              <TabsTrigger value="debate" className="text-sm font-semibold">
+                Live debate mode
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="single" className="space-y-4">
+              <ArgumentForm
+                onAnalysisRequested={handleAnalysisRequested}
+                isLoading={isLoading}
+              />
+              <div ref={resultsRef} className="mt-2">
+                <ResultsDisplay
+                  result={result}
+                  isLoading={isLoading}
+                  error={error}
+                  selectedModel={selectedModel}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="comparison" className="space-y-4">
+              <ComparisonForm onComparisonReady={handleComparisonRequested} />
+              <div ref={comparisonRef} className="mt-2">
+                <ComparisonResults
+                  result={comparisonResult}
+                  isLoading={comparisonLoading}
+                  error={comparisonError}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="debate" className="space-y-4">
+              <DebateArena onDebateUpdate={handleDebateUpdate} />
+              <div ref={debateRef}>
+                {debateRounds.length > 0 && debateMomentum && (
+                  <Card className="neo-card">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2 text-xl">
+                        <Activity className="h-5 w-5 text-primary" /> Debate summary snapshot
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid md:grid-cols-2 gap-4 text-sm">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Total rounds</p>
+                        <p className="text-2xl font-bold">{debateRounds.length}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">AI model</p>
+                        <p className="text-lg font-semibold">{debateModel}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Trophy className="h-5 w-5 text-primary" />
+                        <span>
+                          Momentum edge: {debateMomentum.affirmative > debateMomentum.negative ? "Affirmative" : "Negative"}
+                        </span>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Momentum spread</p>
+                        <p className="font-semibold">
+                          {Math.round(debateMomentum.affirmative)} vs {Math.round(debateMomentum.negative)}
+                        </p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            </TabsContent>
+          </Tabs>
+
           <div className="mt-6">
             <ApiGuide />
           </div>
@@ -63,3 +167,4 @@ export default function Home() {
     </div>
   );
 }
+

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -25,7 +25,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,4 @@
 import { pgTable, text, serial, integer, boolean, jsonb, timestamp } from "drizzle-orm/pg-core";
-import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
 export const users = pgTable("users", {
@@ -8,9 +7,9 @@ export const users = pgTable("users", {
   password: text("password").notNull(),
 });
 
-export const insertUserSchema = createInsertSchema(users).pick({
-  username: true,
-  password: true,
+export const insertUserSchema = z.object({
+  username: z.string(),
+  password: z.string(),
 });
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
@@ -28,12 +27,12 @@ export const analysisReports = pgTable("analysis_reports", {
 });
 
 // Schema for creating a new analysis report
-export const insertAnalysisReportSchema = createInsertSchema(analysisReports).pick({
-  inputText: true,
-  claim: true,
-  premises: true,
-  emotions: true,
-  aiModel: true
+export const insertAnalysisReportSchema = z.object({
+  inputText: z.string(),
+  claim: z.string(),
+  premises: z.array(z.string()),
+  emotions: z.any(),
+  aiModel: z.string(),
 });
 
 // Emotion scores interface - make optional with defaults


### PR DESCRIPTION
## Summary
- add tabs on the home page to switch between single, comparison, and live debate analyses
- build a dual-argument analyzer with scorecards, similarity scoring, and fallacy heatmaps
- introduce a live debate arena with round tracking, momentum scoring, and supporting insight utilities

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4e5e6e78c83219d74061cb67744bc